### PR TITLE
Add retro minimalist static site for Superintelligent

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — 404</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>404</div>
+        <div class="window-body">
+          <h1>Oj! Fönstret hittades inte</h1>
+          <p>Det verkar som att den sida du söker har rymt tillbaka till 1984. Kanske följde den en annan hyperlänk.</p>
+          <p><a class="button" href="/">Hem</a></p>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,293 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f5f5;
+  --fg: #111;
+  --accent: #0b4bff;
+  --border: rgba(0, 0, 0, 0.4);
+  --shadow: rgba(0, 0, 0, 0.15);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Helvetica Neue", Arial, system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.6;
+  font-size: 17px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.menu {
+  border-bottom: 1px solid var(--border);
+  background: #fff;
+  box-shadow: 0 1px 2px var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.menu .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.menu-logo {
+  font-family: "IBMPlexMono", "SFMono-Regular", "Menlo", monospace;
+  font-size: 20px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+.menu ul {
+  list-style: none;
+  display: flex;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+}
+
+.menu a {
+  padding: 8px 12px;
+  border-radius: 4px;
+  transition: background-color 150ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .menu a {
+    transition: none;
+  }
+}
+
+.menu a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.menu a.active {
+  border: 1px solid var(--border);
+  box-shadow: inset 0 1px 1px var(--shadow);
+}
+
+main {
+  padding: 24px 0 64px;
+}
+
+h1, h2, h3 {
+  font-family: "IBMPlexMono", "SFMono-Regular", "Menlo", monospace;
+  margin-top: 0;
+}
+
+h1 {
+  font-size: 44px;
+  line-height: 1.2;
+}
+
+h2 {
+  font-size: 30px;
+}
+
+h3 {
+  font-size: 22px;
+}
+
+p {
+  margin-bottom: 1.1em;
+}
+
+.window {
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 4px var(--shadow);
+  background: #fff;
+  margin-bottom: 32px;
+}
+
+.window-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: #f0f0f0;
+  font-family: "IBMPlexMono", "SFMono-Regular", "Menlo", monospace;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.window-titlebar .dots {
+  display: inline-flex;
+  gap: 6px;
+  margin-right: 12px;
+}
+
+.window-titlebar .dots span {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--border);
+}
+
+.window-body {
+  padding: 24px;
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 768px) {
+  .grid.two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .grid.three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.step {
+  border-left: 1px solid var(--border);
+  padding-left: 16px;
+}
+
+.pricing {
+  display: grid;
+  gap: 16px;
+}
+
+.pricing .window {
+  margin-bottom: 0;
+}
+
+.button {
+  display: inline-block;
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  background: #fff;
+  box-shadow: 0 2px 4px var(--shadow);
+  color: var(--accent);
+}
+
+.button:hover,
+.button:focus {
+  text-decoration: none;
+}
+
+.footer {
+  border-top: 1px solid var(--border);
+  background: #fff;
+  box-shadow: 0 -2px 4px var(--shadow);
+}
+
+.footer .container {
+  display: grid;
+  gap: 24px;
+}
+
+.footer-cards {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 600px) {
+  .footer-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.footer-card {
+  border: 1px solid var(--border);
+  padding: 16px;
+  box-shadow: 0 2px 4px var(--shadow);
+  background: #fafafa;
+}
+
+.footer-legal {
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.accordion {
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 4px var(--shadow);
+  background: #fff;
+}
+
+.accordion-item + .accordion-item {
+  border-top: 1px solid var(--border);
+}
+
+.accordion-trigger {
+  width: 100%;
+  text-align: left;
+  padding: 16px;
+  font-family: "IBMPlexMono", "SFMono-Regular", "Menlo", monospace;
+  font-size: 18px;
+  background: transparent;
+  border: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.accordion-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.accordion-panel {
+  padding: 0 16px 16px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  h1 {
+    font-size: 34px;
+  }
+  h2 {
+    font-size: 26px;
+  }
+  h3 {
+    font-size: 20px;
+  }
+  body {
+    font-size: 16px;
+  }
+  .menu .container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .menu ul {
+    flex-wrap: wrap;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const normalizedPath = window.location.pathname.replace(/index\.html$/, '') || '/';
+  const links = document.querySelectorAll('.menu a');
+  links.forEach((link) => {
+    const href = link.getAttribute('href');
+    if (!href) return;
+    const hrefPath = new URL(href, window.location.origin).pathname.replace(/index\.html$/, '') || '/';
+    const isHome = normalizedPath === '/' && (hrefPath === '/' || hrefPath === '/index.html');
+    const isExact = hrefPath === normalizedPath;
+    const inServices = normalizedPath.startsWith('/tjanster/') && hrefPath.startsWith('/tjanster/');
+    const inAbout = normalizedPath.startsWith('/om/') && hrefPath.startsWith('/om/');
+    if (isHome || isExact || inServices || inAbout) {
+      link.classList.add('active');
+    }
+  });
+
+  const accordions = document.querySelectorAll('[data-accordion]');
+  accordions.forEach((accordion) => {
+    const triggers = accordion.querySelectorAll('.accordion-trigger');
+    triggers.forEach((trigger) => {
+      const panel = trigger.nextElementSibling;
+      if (!panel) return;
+      panel.hidden = true;
+      panel.setAttribute('tabindex', '-1');
+      trigger.setAttribute('aria-expanded', 'false');
+
+      const toggle = () => {
+        const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+        trigger.setAttribute('aria-expanded', String(!isExpanded));
+        panel.hidden = isExpanded;
+        if (!isExpanded) {
+          panel.focus({ preventScroll: false });
+        } else {
+          trigger.focus({ preventScroll: false });
+        }
+      };
+
+      trigger.addEventListener('click', toggle);
+      trigger.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          toggle();
+        }
+      });
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Hem</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Hemskärm</div>
+        <div class="window-body">
+          <h1>Vi bygger framtiden med mjuk minimalism</h1>
+          <p>Superintelligent är en strategisk partner för organisationer som vill kombinera djup teknisk kompetens med omtänksam design. Vi hämtar inspiration från 1984 års modiga enkelhet och levererar digitala upplevelser där människan alltid kommer först.</p>
+          <a class="button" href="/kontakt.html">Boka ett samtal</a>
+        </div>
+      </section>
+
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Vad vi gör</div>
+        <div class="window-body">
+          <div class="grid two">
+            <div class="step">
+              <h2>Vision till verklighet</h2>
+              <p>Vi översätter stora idéer till handling genom tydliga planer, transparent kommunikation och prototyper som du faktiskt kan använda.</p>
+            </div>
+            <div class="step">
+              <h2>Team som tänker längre</h2>
+              <p>Våra experter inom AI, produktutveckling och organisationsdesign skapar tillsammans lösningar som står sig över tid.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="window" data-accordion>
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>FAQ</div>
+        <div class="window-body">
+          <div class="accordion">
+            <div class="accordion-item">
+              <button class="accordion-trigger" aria-expanded="false">Hur snabbt kan vi starta?<span aria-hidden="true">▾</span></button>
+              <div class="accordion-panel" hidden>
+                <p>Vi planerar alltid uppstart inom två veckor. Under tiden sätter vi ihop rätt team och förbereder arbetsyta, metrik och kommunikation.</p>
+              </div>
+            </div>
+            <div class="accordion-item">
+              <button class="accordion-trigger" aria-expanded="false">Vad gör er annorlunda?<span aria-hidden="true">▾</span></button>
+              <div class="accordion-panel" hidden>
+                <p>Vi tar vårt namn på allvar: intelligens utan ego. Hos oss får du seniora specialister som vågar ställa frågor, tänka klart och leverera resultat utan drama.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/kontakt.html
+++ b/kontakt.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Kontakt</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Kontakt</div>
+        <div class="window-body">
+          <h1>Kontakta Superintelligent</h1>
+          <p>Vi ser fram emot att höra om era idéer. Skriv några rader, boka ett samtal eller bjud in oss till en digital kaffe. Vi svarar inom ett dygn.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Direktlinjer</div>
+        <div class="window-body">
+          <div class="grid two">
+            <div class="step">
+              <h2>Thomas</h2>
+              <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+              <p>E-post: <a href="mailto:thomas@superintelligent.se">thomas@superintelligent.se</a></p>
+            </div>
+            <div class="step">
+              <h2>Martin</h2>
+              <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+              <p>E-post: <a href="mailto:martin@superintelligent.se">martin@superintelligent.se</a></p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Koordinater</div>
+        <div class="window-body">
+          <p>Vi sitter i Stockholm, men jobbar globalt. Vårt kontor är ett retrodoftande labb med skön musik och en hel vägg full av skisser. Hör av dig om du vill komma förbi!</p>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/metod.html
+++ b/metod.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Metod</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Metod</div>
+        <div class="window-body">
+          <h1>Metod i tre handlingar</h1>
+          <p>Vår metod är slipad i komplexa organisationer och snabbfotade startups. Vi fokuserar på tydlighet, tempo och lärande. Varje uppdrag startar med en gemensam karta, itereras i tydliga sprintar och landar i självförsörjande team.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Process</div>
+        <div class="window-body">
+          <div class="grid three">
+            <div class="step">
+              <h2>Diagnos</h2>
+              <p>Vi identifierar systemiska hinder genom intervjuer, data och snabba experiment. Resultatet blir ett tydligt problemstatement alla kan samlas kring.</p>
+            </div>
+            <div class="step">
+              <h2>Design</h2>
+              <p>Tillsammans skissar vi målbilden. Vi använder visualiseringar, användarresor och tekniska ritningar för att låsa upp gemensam förståelse.</p>
+            </div>
+            <div class="step">
+              <h2>Distribution</h2>
+              <p>Vi levererar i veckotakt, med kontinuerliga demo-sessioner och öppna backloggar. All dokumentation lever i samma "window"-stil som denna sajt.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/om/filosofi.html
+++ b/om/filosofi.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Om: Filosofi</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Filosofi</div>
+        <div class="window-body">
+          <h1>Vår filosofi: teknik med värme</h1>
+          <p>Superintelligent tror på en framtid där tekniken förstärker det mänskliga. Vi väljer samarbeten där resultatet förbättrar människors vardag och där teamen växer i processen.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Principer</div>
+        <div class="window-body">
+          <ul>
+            <li><strong>Radikal klarhet:</strong> Vi talar om vad som är sant, även när det är svårt.</li>
+            <li><strong>Tempo med omtanke:</strong> Snabba beslut måste alltid följas av snabba feedback-loopar.</li>
+            <li><strong>Alltid lärande:</strong> Varje leverans dokumenteras så att andra kan följa och förbättra.</li>
+          </ul>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Läs vidare</div>
+        <div class="window-body">
+          <ul>
+            <li><a href="/om/varfor.html">Varför vi finns</a></li>
+            <li><a href="/om/varderingar.html">Våra värderingar</a></li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/om/varderingar.html
+++ b/om/varderingar.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Om: Värderingar</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Värderingar</div>
+        <div class="window-body">
+          <h1>Våra värderingar</h1>
+          <p>Värderingarna är vår kompassenhet. De hjälper oss att göra rätt val när tempot är högt, budgeten liten och insatserna stora.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Kärnor</div>
+        <div class="window-body">
+          <div class="grid three">
+            <div class="step">
+              <h2>Generositet</h2>
+              <p>Vi delar allt vi lär oss. Kod, ritningar och processer blir öppna dokument.</p>
+            </div>
+            <div class="step">
+              <h2>Mod</h2>
+              <p>Vi vågar bygga nytt, avsluta det som inte fungerar och säga ifrån när något känns fel.</p>
+            </div>
+            <div class="step">
+              <h2>Lekfull disciplin</h2>
+              <p>Vi arbetar strukturerat men tillåter alltid en gnutta humor. Resultatet blir hållbart tempo utan att glädjen försvinner.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/om/varfor.html
+++ b/om/varfor.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Om: Varför</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Varför</div>
+        <div class="window-body">
+          <h1>Varför Superintelligent finns</h1>
+          <p>Vi startade för att hjälpa organisationer navigera komplexa beslut där människor och maskiner möts. Vi tror att nordisk omtanke kombinerat med teknisk spets gör skillnaden när världen går från analog till autonom.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Historik</div>
+        <div class="window-body">
+          <p>Thomas och Martin möttes i en innovationstunnelbana i Stockholm. Efter att ha byggt system för allt från vård till finans såg de hur samma problem återkom: verktyg utan känsla. Superintelligent blev svaret.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Teamets puls</div>
+        <div class="window-body">
+          <p>Varje fredag håller vi en "1984-demo" där vi visar vad som skapats under veckan. Det håller oss ödmjuka, lekfulla och nära våra kunder.</p>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/ramverk.html
+++ b/ramverk.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Ramverk</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Ramverk</div>
+        <div class="window-body">
+          <h1>Ramverk som ger trygghet och tempo</h1>
+          <p>Vi kombinerar moderna AI-ramverk med klassisk produktledarskap. Fokus ligger på att skapa tydliga principer som är lika enkla att leva som att läsa. Här är några av våra favoritramar.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Bibliotek</div>
+        <div class="window-body">
+          <ul>
+            <li><strong>Signalstyrka:</strong> En metod för att prioritera experiment baserat på datakvalitet och kundnytta.</li>
+            <li><strong>Orakelcykeln:</strong> En AI-first sprintmodell där vi växlar mellan lärande, förädling och leverans.</li>
+            <li><strong>Människor före maskiner:</strong> Ett beslutsfilter som säkerställer att automation aldrig skadar teamets motivation.</li>
+          </ul>
+        </div>
+      </section>
+      <section class="window" data-accordion>
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Implementation</div>
+        <div class="window-body">
+          <div class="accordion">
+            <div class="accordion-item">
+              <button class="accordion-trigger" aria-expanded="false">Hur införs ramverket?<span aria-hidden="true">▾</span></button>
+              <div class="accordion-panel" hidden>
+                <p>Vi startar med pilotteam som får stöd av våra coacher. När mönstren sitter skalar vi till resten av organisationen, med tydlig dokumentation och sessioner för reflektion.</p>
+              </div>
+            </div>
+            <div class="accordion-item">
+              <button class="accordion-trigger" aria-expanded="false">Kan vi kombinera med egna processer?<span aria-hidden="true">▾</span></button>
+              <div class="accordion-panel" hidden>
+                <p>Absolut. Våra ramverk är modulära och kan vävas in i era befintliga strukturer. Vi hjälper er identifiera vilka delar som ger mest effekt utan att skapa friktion.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/tjanster/bemanning.html
+++ b/tjanster/bemanning.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Tjänster: Bemanning</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Bemanning</div>
+        <div class="window-body">
+          <h1>Bemanning som känns som förstärkning, inte inhyrning</h1>
+          <p>När ni behöver förstärka teamet med erfaren kompetens kliver våra konsulter in utan friktion. Vi matchar er med produktledare, AI-strateger, designers och utvecklare som snabbt blir en del av er kultur.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Kompetenser</div>
+        <div class="window-body">
+          <div class="grid two">
+            <div class="step">
+              <h2>Teknik</h2>
+              <p>Fullstackutvecklare, ML-ingenjörer och dataanalytiker som bygger robusta system med glimten i ögat.</p>
+            </div>
+            <div class="step">
+              <h2>Ledarskap</h2>
+              <p>Produktchefer och transformationsledare som driver förändring genom empati, tydlig riktning och mod att prioritera.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Så funkar det</div>
+        <div class="window-body">
+          <ol>
+            <li>Vi definierar uppdraget tillsammans och pekar ut vad som krävs första veckan.</li>
+            <li>Ni får träffa två till tre profiler och välja vem som känns rätt.</li>
+            <li>Efter onboardingen gör vi kontinuerliga retro-samtal för att säkerställa effekt.</li>
+          </ol>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/tjanster/forelasningar.html
+++ b/tjanster/forelasningar.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Tjänster: Föreläsningar</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Föreläsningar</div>
+        <div class="window-body">
+          <h1>Föreläsningar som väcker nya perspektiv</h1>
+          <p>Thomas och Martin älskar scenen. Vi bjuder på berättelser, live-demonstrationer och tydliga takeaway-listor. Publiken lämnar rummet med energi och en lista på nästa steg.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Teman</div>
+        <div class="window-body">
+          <ul>
+            <li><strong>Den mänskliga algoritmen:</strong> Hur vi samarbetar med AI utan att förlora kreativiteten.</li>
+            <li><strong>Retroframtiden:</strong> Vad vi lär oss av 1984 års produktdesign för att bygga nästa generations upplevelser.</li>
+            <li><strong>Organisationer på turbo:</strong> Processer och kultur som klarar hypersnabb leverans.</li>
+          </ul>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Boka</div>
+        <div class="window-body">
+          <p>Skicka ett mejl till <a href="mailto:hello@superintelligent.se">hello@superintelligent.se</a> och berätta om er publik. Vi svarar med förslag på upplägg, manus och eventuella interaktiva moment.</p>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/tjanster/traning.html
+++ b/tjanster/traning.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Tjänster: Träning</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>AI-träning</div>
+        <div class="window-body">
+          <h1>Träning för team som vill bli superintelligenta</h1>
+          <p>Vi tränar produktteam, ledningsgrupper och supportorganisationer i hur man arbetar tillsammans med AI. Varje träningspass är hands-on och utgår från era data, era utmaningar och ert tempo.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Paket</div>
+        <div class="window-body">
+          <div class="pricing">
+            <div class="window">
+              <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Kickstart</div>
+              <div class="window-body">
+                <p>En intensiv heldag där vi går från teori till prototyp. Perfekt för team som vill förstå möjligheterna utan att drunkna i buzzwords.</p>
+              </div>
+            </div>
+            <div class="window">
+              <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Residens</div>
+              <div class="window-body">
+                <p>Vi bor i ert team under tre veckor, designar ritualer och gör era verktyg smartare. Lärande sker i vardagen, inte i konferensrum.</p>
+              </div>
+            </div>
+            <div class="window">
+              <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Masterclass</div>
+              <div class="window-body">
+                <p>En sex veckors progression med veckovisa uppdrag och live-labb. Avslutas med en showcase där ni demonstrerar era nya AI-färdigheter.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Fler tjänster</div>
+        <div class="window-body">
+          <ul>
+            <li><a href="/tjanster/utbildningar.html">Utbildningar</a> för ledare som vill fatta bättre beslut.</li>
+            <li><a href="/tjanster/forelasningar.html">Föreläsningar</a> som väcker organisationens fantasi.</li>
+            <li><a href="/tjanster/bemanning.html">Bemanning</a> när ni behöver förstärka med smarta människor.</li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/tjanster/utbildningar.html
+++ b/tjanster/utbildningar.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Superintelligent — Tjänster: Utbildningar</title>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+  <header class="menu" role="banner">
+    <div class="container">
+      <a class="menu-logo" href="/">Superintelligent</a>
+      <nav aria-label="MenuBar">
+        <ul>
+          <li><a href="/">Hem</a></li>
+          <li><a href="/metod.html">Metod</a></li>
+          <li><a href="/ramverk.html">Ramverk</a></li>
+          <li><a href="/tjanster/traning.html">Tjänster</a></li>
+          <li><a href="/om/filosofi.html">Om</a></li>
+          <li><a href="/kontakt.html">Kontakt</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <div class="container">
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Utbildningar</div>
+        <div class="window-body">
+          <h1>Utbildningar som gör ledare datadrivna</h1>
+          <p>Vi erbjuder skräddarsydda utbildningar för chefer, styrelser och offentliga organisationer. Fokus ligger på att förstå teknikens konsekvenser och hur man styr mot ansvarfull innovation.</p>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Moduler</div>
+        <div class="window-body">
+          <ol>
+            <li><strong>Strategisk AI-kompass:</strong> Kartlägg var AI faktiskt gör skillnad i er verksamhet.</li>
+            <li><strong>Etik i praktiken:</strong> Ramverk för riskbedömning, ansvar och transparens.</li>
+            <li><strong>Dataplattformar:</strong> Hands-on session där vi bygger en minimal pipeline och visar hur beslut blir bättre med rätt data.</li>
+          </ol>
+        </div>
+      </section>
+      <section class="window">
+        <div class="window-titlebar"><span class="dots" aria-hidden="true"><span></span><span></span><span></span></span>Relaterade erbjudanden</div>
+        <div class="window-body">
+          <ul>
+            <li><a href="/tjanster/traning.html">AI-träning</a> för era produktteam.</li>
+            <li><a href="/tjanster/forelasningar.html">Föreläsningar</a> som inspirerar hela organisationen.</li>
+            <li><a href="/tjanster/bemanning.html">Bemanning</a> som ger er långsiktig kompetens.</li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+      <div class="footer-cards">
+        <div class="footer-card">
+          <h3>Thomas</h3>
+          <p>Tel: <a href="tel:+46734034343">+46 73 403 43 43</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+        <div class="footer-card">
+          <h3>Martin</h3>
+          <p>Tel: <a href="tel:+46703640322">+46 70 364 03 22</a></p>
+          <p><a href="#">WhatsApp</a> · <a href="#">LinkedIn</a></p>
+        </div>
+      </div>
+      <p class="footer-legal">© Superintelligent 1984–∞. Alla pixlar räknas. Inga robotar skadades under skapandet av denna webbplats.</p>
+    </div>
+  </footer>
+  <script src="/assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold a multi-page static site with shared MenuBar, DockFooter, and retro window-inspired layout
- add monochrome 1984-inspired styling with reusable components and responsive tweaks
- implement lightweight JavaScript to highlight active navigation links and provide accessible accordion interactions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d9121154848321966585afe05804be